### PR TITLE
Enable long press on touch devices

### DIFF
--- a/script.js
+++ b/script.js
@@ -253,7 +253,7 @@
       }
 
       let lp;
-      cell.addEventListener('mousedown', () => {
+      const startPress = () => {
         lp = setTimeout(() => {
           cell.dataset.longPressed = 'true';
           blink(cell, () => {
@@ -263,8 +263,12 @@
             delete cell.dataset.longPressed;
           });
         }, 10000);
-      });
-      ['mouseup','mouseleave'].forEach(evt => cell.addEventListener(evt, () => clearTimeout(lp)));
+      };
+      const cancelPress = () => clearTimeout(lp);
+      ['mousedown', 'touchstart'].forEach(evt =>
+        cell.addEventListener(evt, startPress));
+      ['mouseup', 'mouseleave', 'touchend', 'touchcancel'].forEach(evt =>
+        cell.addEventListener(evt, cancelPress));
 
       cell.addEventListener('click', e => {
         if (cell.dataset.longPressed) {


### PR DESCRIPTION
## Summary
- handle `touchstart`/`touchend` events when detecting long presses

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68549a67d988832cbc3cf9dd5e17660f